### PR TITLE
Fix input files for partitioned hive tables, and add test

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2594,9 +2594,7 @@ class Dataset[T] private[sql](
    * @since 2.0.0
    */
   def inputFiles: Array[String] = {
-    val files: Seq[String] = logicalPlan.collect {
-      case LogicalRelation(HadoopFsRelation(location: FileCatalog, _, _, _, _, _), _, _) =>
-        location.inputFiles
+    val files: Seq[String] = queryExecution.optimizedPlan.collect {
       case LogicalRelation(fsBasedRelation: FileRelation, _, _) =>
         fsBasedRelation.inputFiles
       case fr: FileRelation =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/TableFileCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/TableFileCatalog.scala
@@ -72,7 +72,6 @@ class TableFileCatalog(
 
   override def refresh(): Unit = {}
 
-
   /**
    * Returns a [[ListingFileCatalog]] for this table restricted to the subset of partitions
    * specified by the given partition-pruning filters.
@@ -96,6 +95,8 @@ class TableFileCatalog(
 
     new ListingFileCatalog(sparkSession, rootPaths, parameters, partitionSchema)
   }
+
+  override def inputFiles: Array[String] = filterPartitions(Nil).inputFiles
 
   private def listDataLeafFiles(paths: Seq[Path]) =
     listLeafFiles(paths).filter(f => isDataPath(f.getPath))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/fileSourceInterfaces.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
+import org.apache.spark.sql.execution.FileRelation
 import org.apache.spark.sql.sources.{BaseRelation, DataSourceRegister, Filter}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
@@ -139,7 +140,7 @@ case class HadoopFsRelation(
     bucketSpec: Option[BucketSpec],
     fileFormat: FileFormat,
     options: Map[String, String])(val sparkSession: SparkSession)
-  extends BaseRelation {
+  extends BaseRelation with FileRelation {
 
   override def sqlContext: SQLContext = sparkSession.sqlContext
 
@@ -161,6 +162,8 @@ case class HadoopFsRelation(
   }
 
   override def sizeInBytes: Long = location.sizeInBytes
+
+  override def inputFiles: Array[String] = location.inputFiles
 }
 
 /**
@@ -339,6 +342,9 @@ trait BasicFileCatalog {
    */
   def listFiles(filters: Seq[Expression]): Seq[Partition]
 
+  /** Returns the list of files that will be read when scanning this relation. */
+  def inputFiles: Array[String]
+
   /** Refresh any cached file listings */
   def refresh(): Unit
 
@@ -360,8 +366,7 @@ trait FileCatalog extends BasicFileCatalog {
   /** Returns all the valid files. */
   def allFiles(): Seq[FileStatus]
 
-  /** Returns the list of files that will be read when scanning this relation. */
-  def inputFiles: Array[String] =
+  override def inputFiles: Array[String] =
     allFiles().map(_.getPath.toUri.toString).toArray
 
   override def sizeInBytes: Long = allFiles().map(_.getLen).sum

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDataFrameSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDataFrameSuite.scala
@@ -36,7 +36,7 @@ class HiveDataFrameSuite extends QueryTest with TestHiveSingleton with SQLTestUt
     assert(hiveClient.getConf("hive.in.test", "") == "true")
   }
 
-  test("inputFiles of pruned and partitioned table") {
+  test("partitioned pruned table reports only selected files") {
     withTable("test") {
       withTempDir { dir =>
         spark.range(5).selectExpr("id", "id as f1", "id as f2").write


### PR DESCRIPTION
It was previously broken, since the logical plan contained only TableFileCatalogs. This changes HadoopFsRelation back to implement FileRelation, and implements inputFiles in all cases.

Also switch the Dataset inputFiles implementation to select from the optimized logical plan, to avoid listing all files in the pruned cases. This doubles as a very primitive correctness test for the pruning optimization.
