### PR TITLE
Make sure to preserve partition metadata from the metastore

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/TableFileCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/TableFileCatalog.scala
@@ -113,20 +113,6 @@ private class PrunedTableFileCatalog(
     override val partitionSpec: PartitionSpec)
   extends ListingFileCatalog(
     sparkSession,
-    PrunedTableFileCatalog.getPaths(tableBasePath, partitionSpec),
+    partitionSpec.partitions.map(_.path),
     Map.empty,
-    Some(partitionSpec.partitionColumns)) {
-}
-
-object PrunedTableFileCatalog {
-  /** Get the list of paths to list files in the for a metastore table */
-  def getPaths(tableBasePath: Path, partitionSpec: PartitionSpec): Seq[Path] = {
-    // If there are no partitions currently specified then use base path,
-    // otherwise use the paths corresponding to the partitions.
-    if (partitionSpec.partitions.isEmpty) {
-      Seq(tableBasePath)
-    } else {
-      partitionSpec.partitions.map(_.path)
-    }
-  }
-}
+    Some(partitionSpec.partitionColumns))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -643,12 +643,8 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
             val index = partitionSchema.indexWhere(_.name == att.name)
             BoundReference(index, partitionSchema(index).dataType, nullable = true)
         })
-      clientPrunedPartitions.filter { case CatalogTablePartition(spec, _, _) =>
-        val row =
-          InternalRow.fromSeq(partitionSchema.map { case StructField(name, dataType, _, _) =>
-            Cast(Literal(spec(name)), dataType).eval()
-          })
-        boundPredicate(row)
+      clientPrunedPartitions.filter { case p: CatalogTablePartition =>
+        boundPredicate(p.toRow(partitionSchema))
       }
     } else {
       client.getPartitions(catalogTable)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDataFrameSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDataFrameSuite.scala
@@ -62,6 +62,10 @@ class HiveDataFrameSuite extends QueryTest with TestHiveSingleton with SQLTestUt
         val df3 = spark.sql("select * from test where PARTCOL1 = 3 or partcol2 = 4")
         assert(df3.count() == 2)
         assert(df3.inputFiles.length == 2)
+
+        val df4 = spark.sql("select * from test where partCol1 = 999")
+        assert(df4.count() == 0)
+        assert(df4.inputFiles.length == 0)
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDataFrameSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDataFrameSuite.scala
@@ -39,14 +39,14 @@ class HiveDataFrameSuite extends QueryTest with TestHiveSingleton with SQLTestUt
   test("partitioned pruned table reports only selected files") {
     withTable("test") {
       withTempDir { dir =>
-        spark.range(5).selectExpr("id", "id as f1", "id as f2").write
-          .partitionBy("f1", "f2")
+        spark.range(5).selectExpr("id", "id as partCol1", "id as partCol2").write
+          .partitionBy("partCol1", "partCol2")
           .mode("overwrite")
           .parquet(dir.getAbsolutePath)
 
         spark.sql(s"""
           |create external table test (id long)
-          |partitioned by (f1 int, f2 int)
+          |partitioned by (partCol1 int, partCol2 int)
           |stored as parquet
           |location "${dir.getAbsolutePath}"""".stripMargin)
         spark.sql("msck repair table test")
@@ -55,9 +55,13 @@ class HiveDataFrameSuite extends QueryTest with TestHiveSingleton with SQLTestUt
         assert(df.count() == 5)
         assert(df.inputFiles.length == 5)  // unpruned
 
-        val df2 = spark.sql("select * from test where f2 = 3 or f2 = 4")
+        val df2 = spark.sql("select * from test where partCol1 = 3 or partCol2 = 4")
         assert(df2.count() == 2)
         assert(df2.inputFiles.length == 2)  // pruned, so we have less files
+
+        val df3 = spark.sql("select * from test where PARTCOL1 = 3 or partcol2 = 4")
+        assert(df3.count() == 2)
+        assert(df3.inputFiles.length == 2)
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetadataCacheSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetadataCacheSuite.scala
@@ -60,38 +60,44 @@ class HiveMetadataCacheSuite extends QueryTest with SQLTestUtils with TestHiveSi
     }
   }
 
-  test("partitioned table is cached when partition pruning is off") {
-    withSQLConf("spark.sql.hive.filesourcePartitionPruning" -> "false") {
-      withTable("test") {
-        withTempDir { dir =>
-          spark.range(5).selectExpr("id", "id as f1", "id as f2").write
-            .partitionBy("f1", "f2")
-            .mode("overwrite")
-            .parquet(dir.getAbsolutePath)
+  def testCaching(pruningEnabled: Boolean): Unit = {
+    test(s"partitioned table is cached when partition pruning is $pruningEnabled") {
+      withSQLConf("spark.sql.hive.filesourcePartitionPruning" -> pruningEnabled.toString) {
+        withTable("test") {
+          withTempDir { dir =>
+            spark.range(5).selectExpr("id", "id as f1", "id as f2").write
+              .partitionBy("f1", "f2")
+              .mode("overwrite")
+              .parquet(dir.getAbsolutePath)
 
-          spark.sql(s"""
-            |create external table test (id long)
-            |partitioned by (f1 int, f2 int)
-            |stored as parquet
-            |location "${dir.getAbsolutePath}"""".stripMargin)
-          spark.sql("msck repair table test")
+            spark.sql(s"""
+              |create external table test (id long)
+              |partitioned by (f1 int, f2 int)
+              |stored as parquet
+              |location "${dir.getAbsolutePath}"""".stripMargin)
+            spark.sql("msck repair table test")
 
-          val df = spark.sql("select * from test")
-          assert(sql("select * from test").count() == 5)
+            val df = spark.sql("select * from test")
+            assert(sql("select * from test").count() == 5)
 
-          // Delete a file, then assert that we tried to read it. This means the table was cached.
-          val p = new Path(spark.table("test").inputFiles.head)
-          assert(p.getFileSystem(hiveContext.sessionState.newHadoopConf()).delete(p, false))
-          val e = intercept[SparkException] {
-            sql("select * from test").count()
+            // Delete a file, then assert that we tried to read it. This means the table was cached.
+            val p = new Path(spark.table("test").inputFiles.head)
+            assert(p.getFileSystem(hiveContext.sessionState.newHadoopConf()).delete(p, true))
+            val e = intercept[SparkException] {
+              sql("select * from test").count()
+            }
+            assert(e.getMessage.contains("FileNotFoundException"))
+
+            // Test refreshing the cache.
+            spark.catalog.refreshTable("test")
+            assert(sql("select * from test").count() == 4)
           }
-          assert(e.getMessage.contains("FileNotFoundException"))
-
-          // Test refreshing the cache.
-          spark.catalog.refreshTable("test")
-          assert(sql("select * from test").count() == 4)
         }
       }
     }
+  }
+
+  for (pruningEnabled <- Seq(true, false)) {
+    testCaching(pruningEnabled)
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
@@ -586,6 +586,9 @@ class ParquetMetastoreSuite extends ParquetPartitioningTest {
         checkAnswer(
           sql("SELECT * FROM test_added_partitions"),
           Seq(("foo", 0), ("bar", 0), ("baz", 1)).toDF("a", "b"))
+
+        // Also verify the inputFiles implementation
+        assert(sql("select * from test_added_partitions").inputFiles.length == 2)
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
@@ -587,6 +587,14 @@ class ParquetMetastoreSuite extends ParquetPartitioningTest {
           sql("SELECT * FROM test_added_partitions"),
           Seq(("foo", 0), ("bar", 0), ("baz", 1)).toDF("a", "b"))
 
+        // Check it with pruning predicates
+        checkAnswer(
+          sql("SELECT * FROM test_added_partitions where b = 1"),
+          Seq(("baz", 1)).toDF("a", "b"))
+        checkAnswer(
+          sql("SELECT * FROM test_added_partitions where b = 0"),
+          Seq(("foo", 0), ("bar", 0)).toDF("a", "b"))
+
         // Also verify the inputFiles implementation
         assert(sql("select * from test_added_partitions").inputFiles.length == 2)
       }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
@@ -589,14 +589,20 @@ class ParquetMetastoreSuite extends ParquetPartitioningTest {
 
         // Check it with pruning predicates
         checkAnswer(
+          sql("SELECT * FROM test_added_partitions where b = 0"),
+          Seq(("foo", 0), ("bar", 0)).toDF("a", "b"))
+        checkAnswer(
           sql("SELECT * FROM test_added_partitions where b = 1"),
           Seq(("baz", 1)).toDF("a", "b"))
         checkAnswer(
-          sql("SELECT * FROM test_added_partitions where b = 0"),
-          Seq(("foo", 0), ("bar", 0)).toDF("a", "b"))
+          sql("SELECT * FROM test_added_partitions where b = 2"),
+          Seq[(String, Int)]().toDF("a", "b"))
 
         // Also verify the inputFiles implementation
         assert(sql("select * from test_added_partitions").inputFiles.length == 2)
+        assert(sql("select * from test_added_partitions where b = 0").inputFiles.length == 1)
+        assert(sql("select * from test_added_partitions where b = 1").inputFiles.length == 1)
+        assert(sql("select * from test_added_partitions where b = 2").inputFiles.length == 0)
       }
     }
   }


### PR DESCRIPTION
The reason is that ListingFileCatalog only takes in raw file paths, not including the original partition metadata. So for partitions that don't conform to the standard directory layout, we would lose their original partition metadata if we didn't explicitly propagate it.
