### PR TITLE
Fix failed Filter null check due to constraints change under nested column pruning

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -166,7 +166,9 @@ case class FilterExec(condition: Expression, child: SparkPlan)
     val generatedIsNotNullChecks = new Array[Boolean](notNullPreds.length)
     val generated = otherPreds.map { c =>
       val nullChecks = c.references.map { r =>
-        val idx = notNullPreds.indexWhere { n => n.asInstanceOf[IsNotNull].child.semanticEquals(r)}
+        val idx = notNullPreds.indexWhere { n =>
+          n.asInstanceOf[IsNotNull].child.references.contains(r)
+        }
         if (idx != -1 && !generatedIsNotNullChecks(idx)) {
           generatedIsNotNullChecks(idx) = true
           // Use the child's output. The nullability is what the child produced.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Correct null check logic in `FilterExec` doesn't work anymore if we move to nested column pruning, especially for the change in `IsNotNull` constraints.

Assume there is a constraint `IsNotNull(a.b)` and the filter predicates are `a.b > 1 && IsNotNull(a.b)`. `FilterExec` will set the nullability of its output attribute `a` to false and use this output to generate predicate codes. Since `a` is non-nullable now and the gen'd code of `a.b > 1` doesn't check if `a` can be null or not now. `FilterExec` normally will put the null check ahead of predicate codes if necessary. But the logic to see if it is needed to put the null check fails because the attribute `a`  in the predicate `a.b > 1` is not the child of `IsNotNull` now. We should check if the attribute is referred by the `IsNotNull` instead.

## How was this patch tested?

Added a related test.